### PR TITLE
#26 [FEAT] 비밀번호 찾기 구현

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,4 +1,6 @@
 import EmailVerify from "@/pages/auth/EmailVerify";
+import FindPassword from "@/pages/auth/FindPassword";
+import ResetPassword from "@/pages/auth/ResetPassword";
 import Login from "@/pages/auth/Login";
 import PersonalInfo from "@/pages/auth/PersonalInfo";
 import Register from "@/pages/auth/Register";
@@ -57,6 +59,16 @@ export default function RootNavigator() {
       <Stack.Screen
         name="StampTour"
         component={StampTour}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="FindPassword"
+        component={FindPassword}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="ResetPassword"
+        component={ResetPassword}
         options={{ headerShown: false }}
       />
     </Stack.Navigator>

--- a/src/pages/auth/FindPassword.tsx
+++ b/src/pages/auth/FindPassword.tsx
@@ -1,0 +1,130 @@
+import Layout from "@/components/Layout";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import { useNavigation } from "@react-navigation/native";
+import { useState } from "react";
+import { Keyboard, Text, TouchableWithoutFeedback, View } from "react-native";
+
+const MOCK_CODE = "1234";
+
+export default function FindPassword() {
+  const navigation = useNavigation<any>();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
+  const [code, setCode] = useState("");
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [codeError, setCodeError] = useState(false);
+
+  const handleSendCode = () => {
+    if (!email.includes("@")) {
+      setEmailError(true);
+      return;
+    }
+    setEmailError(false);
+    setCodeSent(true);
+    setCode("");
+    setCodeVerified(false);
+    setCodeError(false);
+  };
+
+  const handleVerifyCode = () => {
+    if (code === MOCK_CODE) {
+      setCodeVerified(true);
+      setCodeError(false);
+    } else {
+      setCodeError(true);
+    }
+  };
+
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <View className="flex-1">
+        <Layout title="비밀번호 찾기" showBack showCamera={false}>
+          <View className="mt-6 gap-6 items-center">
+            {/* 이름 */}
+            <Input
+              label="이름"
+              placeholder="이름을 입력해주세요."
+              value={name}
+              onChangeText={setName}
+            />
+
+            {/* 이메일 + 번호발송 */}
+            <View className="w-[342px] gap-[6px]">
+              <View className="flex-row justify-between items-center">
+                <Text className="text-b3 font-sb text-dark-gray">이메일</Text>
+                {emailError && (
+                  <Text className="text-b4 font-rg text-[#FF7B94]">
+                    해당하는 사용자가 없습니다.
+                  </Text>
+                )}
+              </View>
+              <View className="flex-row gap-2 items-center">
+                <Input
+                  size="with-button"
+                  placeholder="이메일을 입력해주세요."
+                  value={email}
+                  onChangeText={setEmail}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  editable={!codeSent}
+                  error={emailError}
+                />
+                <Button
+                  label={codeSent ? "발송완료" : "번호발송"}
+                  size="short"
+                  state={codeSent ? "inactive" : email.length > 0 ? "active" : "inactive"}
+                  onPress={handleSendCode}
+                />
+              </View>
+            </View>
+
+            {/* 이메일 인증번호 + 인증완료 */}
+            <View className="w-[342px] gap-[6px]">
+              <View className="flex-row justify-between items-center">
+                <Text className="text-b3 font-sb text-dark-gray">
+                  이메일 인증번호
+                </Text>
+                {codeError && (
+                  <Text className="text-b4 font-rg text-[#FF7B94]">
+                    인증번호가 일치하지 않습니다.
+                  </Text>
+                )}
+              </View>
+              <View className="flex-row gap-2 items-center">
+                <Input
+                  size={codeSent ? "with-button" : "default"}
+                  placeholder=""
+                  value={code}
+                  onChangeText={(t) => { setCode(t); setCodeError(false); }}
+                  keyboardType="number-pad"
+                  editable={codeSent && !codeVerified}
+                />
+                {codeSent && (
+                  <Button
+                    label={codeVerified ? "인증완료" : "인증하기"}
+                    size="short"
+                    state={codeVerified ? "inactive" : code.length > 0 ? "active" : "inactive"}
+                    onPress={handleVerifyCode}
+                  />
+                )}
+              </View>
+            </View>
+          </View>
+
+          <View className="items-center py-4 mt-auto">
+            <Button
+              label="비밀번호 변경하기"
+              size="long"
+              state={codeVerified ? "active" : "inactive"}
+              onPress={() => navigation.navigate("ResetPassword")}
+            />
+          </View>
+        </Layout>
+      </View>
+    </TouchableWithoutFeedback>
+  );
+}

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -79,7 +79,7 @@ export default function Login() {
           </Text>
         </TouchableOpacity>
         <Text className="text-[13px] text-gray-400">|</Text>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate("FindPassword")}>
           <Text className="text-b4 font-sb text-dark-gray underline">
             비밀번호 찾기
           </Text>

--- a/src/pages/auth/ResetPassword.tsx
+++ b/src/pages/auth/ResetPassword.tsx
@@ -1,0 +1,90 @@
+import Layout from "@/components/Layout";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import { useNavigation } from "@react-navigation/native";
+import { useState } from "react";
+import {
+  Keyboard,
+  Modal,
+  Text,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
+
+export default function ResetPassword() {
+  const navigation = useNavigation<any>();
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [showModal, setShowModal] = useState(false);
+
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
+  const isPasswordInvalid =
+    password.length > 0 && !passwordRegex.test(password);
+  const isMismatch = confirm.length > 0 && password !== confirm;
+  const isValid = passwordRegex.test(password) && password === confirm;
+
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <View className="flex-1">
+        <Layout title="비밀번호 변경" showBack showCamera={false}>
+          <View className="mt-6 gap-6 items-center">
+            <Input
+              label="비밀번호 설정"
+              description="영문, 숫자 조합 8글자 이상으로 설정해주세요."
+              placeholder="비밀번호를 입력해주세요."
+              value={password}
+              onChangeText={setPassword}
+              autoCapitalize="none"
+              error={isPasswordInvalid}
+            />
+            <Input
+              label="비밀번호 확인"
+              description={
+                isMismatch ? "비밀번호가 일치하지 않습니다." : undefined
+              }
+              placeholder="비밀번호를 한 번 더 입력해주세요."
+              value={confirm}
+              onChangeText={setConfirm}
+              autoCapitalize="none"
+              error={isMismatch}
+            />
+          </View>
+
+          <View className="items-center py-4 mt-auto">
+            <Button
+              label="비밀번호 변경완료"
+              size="long"
+              state={isValid ? "active" : "inactive"}
+              onPress={() => setShowModal(true)}
+            />
+          </View>
+        </Layout>
+
+        {/* 완료 모달 */}
+        <Modal visible={showModal} transparent animationType="fade">
+          <View className="flex-1 items-center justify-center bg-black/40">
+            <View className="bg-white rounded-2xl items-center w-[85%] px-8 py-9 gap-6">
+              <Text className="text-b3 font-sb text-gray-black text-center">
+                비밀번호가 성공적으로 변경되었습니다.
+              </Text>
+              <TouchableOpacity
+                onPress={() => {
+                  setShowModal(false);
+                  navigation.navigate("Login");
+                }}
+                activeOpacity={0.7}
+                className="bg-[#D9D9D9] rounded-2xl px-10 py-3"
+              >
+                <Text className="text-b2 font-sb text-gray-black">
+                  돌아가기
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+      </View>
+    </TouchableWithoutFeedback>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #26 

## 📝작업 내용

> 비밀번호 찾기 페이지 

`src/pages/auth/FindPassword.tsx`, `src/pages/auth/ResetPassword.tsx`

## 🔎코드 설명 및 참고 사항

>
Summary
로그인 화면 "비밀번호 찾기" → 이메일 인증 → 비밀번호 재설정 플로우 구현
기존 Input, Button 컴포넌트 재사용

### 적용 화면
<img width="300" alt="KakaoTalk_20260325_001151449" src="https://github.com/user-attachments/assets/9b53825b-cc6b-478a-84cb-3e148cac5207" />
<img width="300" alt="KakaoTalk_20260325_001151449_01" src="https://github.com/user-attachments/assets/fbbd5558-aeaa-4eee-a022-7ec627fbd418" />
<img width="300"  alt="KakaoTalk_20260325_001151449_02" src="https://github.com/user-attachments/assets/2135c293-941a-46b9-9942-dfe838ae3337" />
<img width="300" alt="KakaoTalk_20260325_001151449_03" src="https://github.com/user-attachments/assets/1cb6ed0f-aba8-46d0-b241-04d2b45c797b" />



## 💬리뷰 요구사항

>
현재 와이어프레임이 최신화 안된것 같습니다. (와이어프레임 완료로 변경시 수정하겠습니다)

## ⚠️로컬 실행 시 유의사항

>
