### PR TITLE
[MOD] HomePoster SparkleParticles 적용 및 NFC Expo Go 호환 처리

### DIFF
--- a/src/components/common/SparkleParticles.tsx
+++ b/src/components/common/SparkleParticles.tsx
@@ -94,7 +94,7 @@ const Particle = memo(function Particle({
     return () => {
       mounted = false;
     };
-  });
+  }, [delay, duration, opacity, scale, translateY]);
 
   return (
     <Animated.View
@@ -116,17 +116,22 @@ const Particle = memo(function Particle({
   );
 });
 
-const generateParticles = (): ParticleConfig[] =>
+const generateParticles = (w: number, h: number): ParticleConfig[] =>
   Array.from({ length: PARTICLE_COUNT }, (_, id) => ({
     id,
-    left: Math.random() * SCREEN_WIDTH,
-    top: Math.random() * SCREEN_HEIGHT,
+    left: Math.random() * w,
+    top: Math.random() * h,
     duration: (Math.random() * 2 + 3) * 1000,
     delay: Math.random() * 5000,
   }));
 
-export default function SparkleParticles() {
-  const particles = useRef(generateParticles()).current;
+interface SparkleParticlesProps {
+  width?: number;
+  height?: number;
+}
+
+export default function SparkleParticles({ width = SCREEN_WIDTH, height = SCREEN_HEIGHT }: SparkleParticlesProps) {
+  const particles = useRef(generateParticles(width, height)).current;
 
   return (
     <>

--- a/src/components/home/HomePoster.tsx
+++ b/src/components/home/HomePoster.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { Animated, StyleSheet, Text, TouchableWithoutFeedback, useWindowDimensions, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
+import SparkleParticles from '@/components/common/SparkleParticles';
 
 const POSTER_HEIGHT_EXPANDED = 500;
 const POSTER_HEIGHT_COLLAPSED = 230;
@@ -23,7 +24,7 @@ export default function HomePoster() {
 
   return (
     <TouchableWithoutFeedback onPress={handlePress}>
-      <Animated.View style={{ width, height: animatedHeight }}>
+      <Animated.View style={{ width, height: animatedHeight, overflow: 'hidden' }}>
         <Image
           source={require('@/assets/pngs/homeposter.png')}
           style={StyleSheet.absoluteFill}
@@ -35,6 +36,9 @@ export default function HomePoster() {
           locations={[0.5933, 1]}
           style={StyleSheet.absoluteFill}
         />
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          <SparkleParticles width={width} height={POSTER_HEIGHT_EXPANDED} />
+        </View>
         <View style={styles.textContainer}>
           <Text style={styles.title}>{"서강대학교 대동제 'Odyssey'"}</Text>
           <Text style={styles.date}>2026.05.13 ~ 2026.05.15</Text>

--- a/src/components/personal/Tag.tsx
+++ b/src/components/personal/Tag.tsx
@@ -6,7 +6,6 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Image as ExpoImage } from "expo-image";
 import { useEffect, useState } from "react";
 import { Image, Text, TouchableOpacity, View } from "react-native";
-import NfcManager, { NfcTech } from "react-native-nfc-manager";
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -16,6 +15,17 @@ import Animated, {
   withSequence,
   withTiming,
 } from "react-native-reanimated";
+
+let NfcManager: any = null;
+let NfcTech: any = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const nfc = require("react-native-nfc-manager");
+  NfcManager = nfc.default;
+  NfcTech = nfc.NfcTech;
+} catch {
+  // Expo Go 환경 — NFC 네이티브 모듈 없음
+}
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
@@ -40,6 +50,7 @@ export default function Tag() {
     let cancelled = false;
 
     const startNfc = async () => {
+      if (!NfcManager) return;
       try {
         await NfcManager.start();
         await NfcManager.requestTechnology(NfcTech.NfcA);
@@ -62,14 +73,14 @@ export default function Tag() {
       } catch (e) {
         // NFC 미지원 기기이거나 취소된 경우 무시
       } finally {
-        NfcManager.cancelTechnologyRequest();
+        NfcManager?.cancelTechnologyRequest();
       }
     };
 
     startNfc();
     return () => {
       cancelled = true;
-      NfcManager.cancelTechnologyRequest();
+      NfcManager?.cancelTechnologyRequest();
     };
   }, []);
 

--- a/src/pages/LoadingScreen.tsx
+++ b/src/pages/LoadingScreen.tsx
@@ -1,4 +1,4 @@
-import SparkleParticles from "@/components/SparkleParticles";
+import SparkleParticles from "@/components/common/SparkleParticles";
 import GotoLogo from "@/assets/svgs/goto.svg";
 import KbLogo from "@/assets/svgs/kblogo.svg";
 import { typo } from "@/styles/typography";


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed: #61 

## 📝작업 내용
>SparkleParticles 리팩토링 및 HomePoster 적용했습니다
`HomePoster.tsx`

>NFC Expo Go 호환성 처리했습니다.
`Tag.tsx`

## 🔎코드 설명 및 참고 사항
>SparkleParticles 리팩토링 및 HomePoster 적용
  - src/components/SparkleParticles.tsx 
     → src/components/common/SparkleParticles.tsx 로 위치 이동 (공통 컴포넌트 분리)
  - HomePoster에 SparkleParticles 파티클 효과 적용
  - HomePoster에 overflow: 'hidden' 추가하여 파티클이 포스터 영역 밖으로 나가지 않도록 처리
  - LoadingScreen import 경로 업데이트

>NFC Expo Go 호환성 처리
  - react-native-nfc-manager를 정적 import에서 런타임 조건부 로딩으로 변경
  - Expo Go 환경에서 NFC 네이티브 모듈이 없어도 앱이 크래시 나지 않도록 처리

### 적용 화면
https://github.com/user-attachments/assets/8e51f8b8-0d9d-42c4-b008-cc22f6ebb388

## 💬리뷰 요구사항
>  체크리스트
  - Expo Go에서 NFC 없이 정상 동작 확인
  - HomePoster 파티클 효과 확인
  - LoadingScreen 파티클 효과 확인

## ⚠️로컬 실행 시 유의사항

>
