### PR TITLE
#83 [FEAT] Apollo Client 인증 토큰 주입 및 자동 갱신 구현

### DIFF
--- a/src/api/apolloClient.ts
+++ b/src/api/apolloClient.ts
@@ -1,13 +1,21 @@
-import { ApolloClient, InMemoryCache, createHttpLink } from "@apollo/client";
+import { ApolloClient, InMemoryCache, createHttpLink, from } from "@apollo/client";
+import { CombinedGraphQLErrors, ServerError } from "@apollo/client/errors";
 import { setContext } from "@apollo/client/link/context";
+import { ErrorLink } from "@apollo/client/link/error";
 import * as SecureStore from "expo-secure-store";
+import { Observable } from "rxjs";
+import { useAuthStore } from "../stores/authStore";
+import { authApi } from "./auth";
 
 const httpLink = createHttpLink({
   uri: `${process.env.EXPO_PUBLIC_API_BASE_URL}/graphql`,
 });
 
 const authLink = setContext(async (_, { headers }) => {
-  const token = await SecureStore.getItemAsync("accessToken");
+  let token = await SecureStore.getItemAsync("accessToken");
+  if (!token) {
+    token = useAuthStore.getState().accessToken;
+  }
   return {
     headers: {
       ...headers,
@@ -16,8 +24,48 @@ const authLink = setContext(async (_, { headers }) => {
   };
 });
 
+const errorLink = new ErrorLink(({ error, operation, forward }) => {
+  const isUnauthorized =
+    (CombinedGraphQLErrors.is(error) &&
+      error.errors.some((e) => e.extensions?.code === "UNAUTHENTICATED")) ||
+    (ServerError.is(error) && error.statusCode === 401);
+
+  if (!isUnauthorized) return;
+
+  return new Observable((observer) => {
+    const { refreshToken, setTokens, clearTokens } = useAuthStore.getState();
+
+    if (!refreshToken) {
+      clearTokens();
+      observer.error(error);
+      return;
+    }
+
+    SecureStore.getItemAsync("accessToken")
+      .then(async (stored) => {
+        const keepLogin = !!stored;
+        const { data } = await authApi.refresh(refreshToken);
+        await setTokens(data.accessToken, data.refreshToken, keepLogin);
+
+        operation.setContext(({ headers = {} }: { headers: Record<string, string> }) => ({
+          headers: { ...headers, Authorization: `Bearer ${data.accessToken}` },
+        }));
+
+        forward(operation).subscribe({
+          next: observer.next.bind(observer),
+          error: observer.error.bind(observer),
+          complete: observer.complete.bind(observer),
+        });
+      })
+      .catch(async () => {
+        await clearTokens();
+        observer.error(error);
+      });
+  });
+});
+
 const apolloClient = new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: from([errorLink, authLink, httpLink]),
   cache: new InMemoryCache(),
 });
 

--- a/src/pages/MDDetail.tsx
+++ b/src/pages/MDDetail.tsx
@@ -72,9 +72,11 @@ export default function MDDetail() {
   const route = useRoute<MDDetailRouteProp>();
   const { id, title, soldOut } = route.params;
 
-  const { data } = useQuery<MdItemDetailResponse>(GET_MD_ITEM_DETAIL, {
+  const { data, loading, error } = useQuery<MdItemDetailResponse>(GET_MD_ITEM_DETAIL, {
     variables: { mdItemId: id },
   });
+
+  if (error) console.error('[MDDetail] query error:', error.message);
 
   const detail = data?.mdItemDetail;
   const images = detail


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed : #83

## 📝작업 내용
> - authLink 수정: SecureStore 없을 시 Zustand store fallback으로 토큰 읽기
> - errorLink 추가: 401 응답 시 refreshToken으로 accessToken 재발급 후 원래 요청 재시도
> - ApolloClient link 체인 순서 변경: errorLink → authLink → httpLink
> - refresh 실패 시 자동 로그아웃 처리

`src/apollo/client.ts`

## 🔎코드 설명 및 참고 사항

>
### 적용 화면


## 💬리뷰 요구사항

>

## ⚠️로컬 실행 시 유의사항

>
