### PR TITLE
#86 [MOD] MD 상세 페이지 UI 개선

### DIFF
--- a/src/components/md/MDImageCarousel.tsx
+++ b/src/components/md/MDImageCarousel.tsx
@@ -1,33 +1,17 @@
-import ArrowLeft from '@/assets/svgs/arrow-left.svg';
-import ArrowRight from '@/assets/svgs/arrow-right.svg';
-import { useState } from 'react';
-import { Image, ImageSourcePropType, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { Image, ImageSourcePropType, Text, useWindowDimensions, View } from 'react-native';
 import { typo } from '@/styles/typography';
 
 interface MDImageCarouselProps {
-  images: ImageSourcePropType[];
+  image: ImageSourcePropType;
   soldOut?: boolean;
 }
 
-export default function MDImageCarousel({ images, soldOut = false }: MDImageCarouselProps) {
+export default function MDImageCarousel({ image, soldOut = false }: MDImageCarouselProps) {
   const { width } = useWindowDimensions();
-  const [currentIndex, setCurrentIndex] = useState(0);
-
-  const handlePrev = () => {
-    setCurrentIndex((prev) => (prev > 0 ? prev - 1 : images.length - 1));
-  };
-
-  const handleNext = () => {
-    setCurrentIndex((prev) => (prev < images.length - 1 ? prev + 1 : 0));
-  };
 
   return (
     <View style={{ width, height: width }}>
-      <Image
-        source={images[currentIndex]}
-        style={{ width, height: width, position: 'absolute' }}
-        resizeMode="cover"
-      />
+      <Image source={image} style={{ width, height: width, position: 'absolute' }} resizeMode="cover" />
 
       {soldOut && (
         <View
@@ -46,62 +30,6 @@ export default function MDImageCarousel({ images, soldOut = false }: MDImageCaro
             SOLD OUT
           </Text>
         </View>
-      )}
-
-      <View
-        style={{
-          position: 'absolute',
-          bottom: 20,
-          left: 0,
-          right: 0,
-          flexDirection: 'row',
-          justifyContent: 'center',
-          gap: 6,
-        }}
-      >
-        {images.map((_, i) => (
-          <View
-            key={i}
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: 3,
-              backgroundColor: `rgba(255,255,255,${i === currentIndex ? 0.8 : 0.4})`,
-            }}
-          />
-        ))}
-      </View>
-
-      {images.length > 1 && (
-        <>
-          <TouchableOpacity
-            onPress={handlePrev}
-            style={{
-              position: 'absolute',
-              left: 16,
-              top: 0,
-              bottom: 0,
-              justifyContent: 'center',
-              padding: 8,
-            }}
-          >
-            <ArrowLeft />
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            onPress={handleNext}
-            style={{
-              position: 'absolute',
-              right: 16,
-              top: 0,
-              bottom: 0,
-              justifyContent: 'center',
-              padding: 8,
-            }}
-          >
-            <ArrowRight />
-          </TouchableOpacity>
-        </>
       )}
     </View>
   );

--- a/src/components/md/MDInform.tsx
+++ b/src/components/md/MDInform.tsx
@@ -9,7 +9,7 @@ const ITEMS = [
 
 export default function ProductInfo() {
   return (
-    <View style={{ marginTop: 16, width: '100%' }}>
+    <View style={{ width: '100%' }}>
       <View
         style={{
           width: '100%',
@@ -17,7 +17,7 @@ export default function ProductInfo() {
           paddingHorizontal: 25,
           borderRadius: 8,
           backgroundColor: '#FFFFFF',
-          gap: 16,
+          gap: 10,
         }}
       >
         <Text className={`${typo.T2_Eb} text-gray-black`}>

--- a/src/components/md/MDProductCard.tsx
+++ b/src/components/md/MDProductCard.tsx
@@ -62,6 +62,7 @@ export default function MDProductCard({ imageSource, title, price, soldOut = fal
       <View
         style={{
           padding: 16,
+          paddingTop:13,
           paddingBottom: 0,
           flexDirection: 'column',
           alignItems: 'flex-start',
@@ -77,7 +78,7 @@ export default function MDProductCard({ imageSource, title, price, soldOut = fal
           {title}
         </Text>
 
-        <Text className={typo.B5_Rg} style={{ color: '#1A1A1A', marginTop: 14, letterSpacing: -0.1 }}>
+        <Text className={typo.B5_Rg} style={{ color: '#1A1A1A', marginTop: 10, letterSpacing: -0.1 }}>
           {price}
         </Text>
       </View>

--- a/src/components/md/MDSaleTypeBadge.tsx
+++ b/src/components/md/MDSaleTypeBadge.tsx
@@ -27,7 +27,7 @@ export default function MDSaleTypeBadge({ type }: MDSaleTypeBadgeProps) {
     <View
       style={{
         paddingHorizontal: 10,
-        paddingVertical: 8,
+        paddingVertical: 6,
         justifyContent: 'center',
         alignItems: 'center',
         gap: 10,

--- a/src/pages/MDDetail.tsx
+++ b/src/pages/MDDetail.tsx
@@ -6,7 +6,8 @@ import { typo } from '@/styles/typography';
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { Image, Text, View } from 'react-native';
+import { Image, Text, useWindowDimensions, View } from 'react-native';
+import { useEffect, useState } from 'react';
 
 const GET_MD_ITEM_DETAIL = gql`
   query MdItemDetail($mdItemId: ID!) {
@@ -18,7 +19,6 @@ const GET_MD_ITEM_DETAIL = gql`
       price
       isSoldOut
       productDescription
-      detailDescription
       optionGroups {
         id
         name
@@ -58,7 +58,6 @@ interface MdItemDetail {
   price: number;
   isSoldOut: boolean;
   productDescription: string;
-  detailDescription: string;
   optionGroups: OptionGroup[];
 }
 
@@ -71,6 +70,8 @@ type MDDetailRouteProp = RouteProp<{ MDDetail: { id: string; title: string; sold
 export default function MDDetail() {
   const route = useRoute<MDDetailRouteProp>();
   const { id, title, soldOut } = route.params;
+  const { width } = useWindowDimensions();
+  const [detailImageHeight, setDetailImageHeight] = useState<number>(0);
 
   const { data, loading, error } = useQuery<MdItemDetailResponse>(GET_MD_ITEM_DETAIL, {
     variables: { mdItemId: id },
@@ -79,18 +80,23 @@ export default function MDDetail() {
   if (error) console.error('[MDDetail] query error:', error.message);
 
   const detail = data?.mdItemDetail;
-  const images = detail
-    ? [{ uri: detail.thumbnailImageUrl }, { uri: detail.detailImageUrl }]
-    : [];
+  const image = detail ? { uri: detail.thumbnailImageUrl } : undefined;
+
+  useEffect(() => {
+    if (!detail?.detailImageUrl) return;
+    Image.getSize(detail.detailImageUrl, (imgWidth, imgHeight) => {
+      setDetailImageHeight((imgHeight / imgWidth) * width);
+    });
+  }, [detail?.detailImageUrl, width]);
 
   return (
     <Layout
       title={detail?.name ?? title}
       showBack
       scrollable
-      fullBleedHeader={<MDImageCarousel images={images} soldOut={detail?.isSoldOut ?? soldOut} />}
+      fullBleedHeader={image && <MDImageCarousel image={image} soldOut={detail?.isSoldOut ?? soldOut} />}
     >
-      <View style={{ paddingTop: 20, paddingHorizontal: 20, alignItems: 'center' }}>
+      <View style={{ paddingTop: 20, alignItems: 'center' }}>
         {/* 뱃지 행 */}
         <View style={{ flexDirection: 'row', gap: 8, width: '100%' }}>
           <MDSaleTypeBadge type="preorder" />
@@ -100,76 +106,54 @@ export default function MDDetail() {
         {/* 제품 이름 */}
         <Text
           className={typo.T2_Eb}
-          style={{ color: '#1A1A1A', letterSpacing: -0.18, marginTop: 16, width: '100%' }}
+          style={{ color: '#1A1A1A', letterSpacing: -0.18, marginTop: 14, width: '100%' }}
         >
           {detail?.name ?? title}
         </Text>
 
-        {/* 가격 */}
+        {/* 가격 + 사이즈 뱃지 */}
         <View
           style={{
             flexDirection: 'row',
             justifyContent: 'space-between',
             alignItems: 'center',
-            marginTop: 8,
+            marginTop: 6,
             width: '100%',
           }}
         >
           <Text className={typo.B3_Rg} style={{ color: '#1A1A1A', letterSpacing: -0.14 }}>
             {detail ? `${detail.price.toLocaleString()}원` : ''}
           </Text>
-        </View>
-
-        {/* 사이즈 뱃지 */}
-        {detail?.optionGroups.map((group) => (
-          <View key={group.id} style={{ width: '100%', marginTop: 12 }}>
-            <Text className={typo.B5_Rg} style={{ color: '#656565', marginBottom: 8 }}>
-              {group.name}
-            </Text>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-              {group.values.map((value) => (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, justifyContent: 'flex-end' }}>
+            {detail?.optionGroups.flatMap((group) =>
+              group.values.map((value) => (
                 <MDSizeBadge key={value.id} size={value.valueName} soldOut={value.isSoldOut} />
-              ))}
-            </View>
+              ))
+            )}
           </View>
-        ))}
+        </View>
 
         {/* 구분선 */}
         <View
           style={{
             height: 1,
             backgroundColor: '#E4E4E4',
-            marginTop: 24,
+            marginTop: 20,
             width: '100%',
           }}
         />
 
         {/* 제품 상세 사진 */}
-        {detail?.detailImageUrl && (
-          <View style={{ alignItems: 'center', marginTop: 24 }}>
+        {detail?.detailImageUrl && detailImageHeight > 0 && (
+          <View style={{ marginTop: 24, width: '100%', marginBottom: 50}}>
             <Image
               source={{ uri: detail.detailImageUrl }}
-              style={{ height: 418.75, alignSelf: 'stretch', aspectRatio: 4 / 5 }}
-              resizeMode="contain"
+              style={{ width: '100%', height: detailImageHeight }}
+              resizeMode="cover"
             />
           </View>
         )}
 
-        {/* 상세설명 */}
-        <Text
-          className={typo.B2_Sb}
-          style={{ color: '#656565', letterSpacing: -0.16, marginTop: 24, width: '100%' }}
-        >
-          상세설명
-        </Text>
-
-        {/* 본문 내용 */}
-        <Text
-          className={typo.B4_Rg}
-          style={{ color: '#1A1A1A', letterSpacing: -0.12, marginTop: 24, marginBottom: 100, width: '100%' }}
-        >
-          {detail?.detailDescription ?? ''}
-        </Text>
       </View>
     </Layout>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed : #86 

## 📝작업 내용
> MDDetail 페이지 전반의 UI를 정리하는 작업 진행했습니다.

`MDDetail.tsx` , `MDImageCarousel.tsx`, `MDProductCard.tsx`

## 🔎코드 설명 및 참고 사항
> 

### 적용 화면
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/3910d268-fab6-404e-8914-253589af3d63" />
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/e1ed59f7-d046-4a8b-96a9-bf80eacaf848" />


## 💬리뷰 요구사항

>

## ⚠️로컬 실행 시 유의사항

>
