### PR TITLE
#65 [MOD] 공지사항 ui 수정

### DIFF
--- a/src/components/more/notice/NoticeDetailBody.tsx
+++ b/src/components/more/notice/NoticeDetailBody.tsx
@@ -1,4 +1,5 @@
-import { View, Text, Image, StyleSheet } from 'react-native';
+import { useState, useEffect } from 'react';
+import { View, Text, Image, StyleSheet, useWindowDimensions } from 'react-native';
 import { typo } from '@/styles/typography';
 import { SvgProps } from 'react-native-svg';
 
@@ -8,12 +9,28 @@ interface NoticeDetailBodyProps {
 }
 
 export default function NoticeDetailBody({ content, image }: NoticeDetailBodyProps) {
+  const { width } = useWindowDimensions();
+  const [imageHeight, setImageHeight] = useState<number>(0);
+
+  useEffect(() => {
+    if (typeof image !== 'string') return;
+    Image.getSize(image, (imgWidth, imgHeight) => {
+      setImageHeight((imgHeight / imgWidth) * width);
+    });
+  }, [image, width]);
+
   return (
     <View style={styles.container}>
       {image && (
         <>
           {typeof image === 'string' ? (
-            <Image source={{ uri: image }} style={styles.image} resizeMode="cover" />
+            imageHeight > 0 && (
+              <Image
+                source={{ uri: image }}
+                style={{ width: '100%', height: imageHeight }}
+                resizeMode="cover"
+              />
+            )
           ) : (
             (() => {
               const SvgImage = image;
@@ -33,11 +50,6 @@ export default function NoticeDetailBody({ content, image }: NoticeDetailBodyPro
 const styles = StyleSheet.create({
   container: {
     alignSelf: 'stretch',
-  },
-  image: {
-    height: 131,
-    alignSelf: 'stretch',
-    borderRadius: 8,
   },
   imageGap: {
     height: 24,

--- a/src/pages/MDDetail.tsx
+++ b/src/pages/MDDetail.tsx
@@ -73,7 +73,7 @@ export default function MDDetail() {
   const { width } = useWindowDimensions();
   const [detailImageHeight, setDetailImageHeight] = useState<number>(0);
 
-  const { data, loading, error } = useQuery<MdItemDetailResponse>(GET_MD_ITEM_DETAIL, {
+  const { data, error } = useQuery<MdItemDetailResponse>(GET_MD_ITEM_DETAIL, {
     variables: { mdItemId: id },
   });
 

--- a/src/pages/more/NoticeDetail.tsx
+++ b/src/pages/more/NoticeDetail.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
   },
   navContainer: {
     marginTop: 40,
-    marginBottom: 20,
+    marginBottom: 40,
   },
   navDivider: {
     height: 1,


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed : #65 

## 📝작업 내용
> 공지사항 상세 페이지 이미지 비율 동적 계산 및 UI 수정

`src/components/more/notice/NoticeDetailBody.tsx`
`src/pages/MDDetail.tsx`
`src/pages/more/NoticeDetail.tsx`
 
## 🔎코드 설명 및 참고 사항
> NoticeDetailBody.tsx
- 기존 고정 높이(131px) 대신 Image.getSize + useWindowDimensions를 사용해 이미지 원본 비율을 유지한 채 화면 너비에 맞게 높이를 동적으로 계산하도록 수정
- imageHeight가 계산되기 전(0인 경우)에는 이미지를 렌더링하지 않아 레이아웃 깜빡임 방지   
> MDDetail.tsx
- useQuery 구조분해에서 사용되지 않던 loading 변수 제거
> NoticeDetail.tsx
- navContainer의 marginBottom 20 → 40 으로 여백 조정


### 적용 화면
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/c4a45e51-fef2-4b97-8c28-03927875ecaf" />


## 💬리뷰 요구사항

>

## ⚠️로컬 실행 시 유의사항

>
