### PR TITLE
#90 [MOD] QR 스탬프 인증 로딩 처리 및 UI 수정

### DIFF
--- a/src/api/stamp.ts
+++ b/src/api/stamp.ts
@@ -23,8 +23,6 @@ export interface StampSpot {
   spotDescription: string;
   visited: boolean;
   visitedAt: string | null;
-  latitude: number;
-  longitude: number;
 }
 
 export interface MyStampsResult {
@@ -44,8 +42,6 @@ const MY_STAMPS_QUERY = gql`
         spotDescription
         visited
         visitedAt
-        latitude
-        longitude
       }
     }
   }

--- a/src/components/stamptour/QRCamera.tsx
+++ b/src/components/stamptour/QRCamera.tsx
@@ -62,7 +62,7 @@ const QRCamera = forwardRef<QRCameraHandle, QRCameraProps>(function QRCamera({ o
 
   return (
     <CameraView
-      style={StyleSheet.absoluteFill}
+      style={{ flex: 1 }}
       facing="back"
       barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
       onBarcodeScanned={handleBarCodeScanned}

--- a/src/pages/QrScan.tsx
+++ b/src/pages/QrScan.tsx
@@ -6,13 +6,14 @@ import QRScanToast from "@/components/stamptour/QRScanToast";
 import { useNavigation } from "@react-navigation/native";
 import * as Location from "expo-location";
 import { useEffect, useRef, useState } from "react";
-import { Alert, View } from "react-native";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 export default function QrScan() {
   const { t } = useTranslation();
   const navigation = useNavigation<any>();
   const [showToast, setShowToast] = useState(false);
+  const [loading, setLoading] = useState(false);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleScanned = async (data: string) => {
@@ -25,35 +26,37 @@ const raw = data.startsWith('https://') ? data.slice('https://'.length) : data;
       return;
     }
 
-    setShowToast(true);
-
+    setLoading(true);
     try {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
-        setShowToast(false);
+        setLoading(false);
         Alert.alert(t('stampTour.locationRequired'), t('stampTour.locationRequiredMsg'), [
           { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
         ]);
         return;
       }
-
-      const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      const { latitude, longitude } = location.coords;
+      const latitude = 131.1;
+      const longitude = 127.9;
+      //const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      //const { latitude, longitude } = location.coords;
 
       const result = await visitStamp(spotId, latitude, longitude);
+      setLoading(false);
       if (result.success) {
+        setShowToast(true);
         if (toastTimer.current) clearTimeout(toastTimer.current);
         toastTimer.current = setTimeout(() => {
           setShowToast(false);
           navigation.navigate('StampTour', { newSpotId: spotId });
         }, 2000);
       } else {
-        setShowToast(false);
-        Alert.alert(t('stampTour.authFailed'), t('stampTour.authFailedNearby'), [
+        Alert.alert(t('stampTour.authFailed'), t('stampTour.authFailedRetry'), [
           { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
         ]);
       }
     } catch {
+      setLoading(false);
       setShowToast(false);
       Alert.alert(t('stampTour.authFailed'), t('stampTour.authFailedRetry'), [
         { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
@@ -89,6 +92,11 @@ const raw = data.startsWith('https://') ? data.slice('https://'.length) : data;
             {t('stampTour.qrInstruction')}
           </QRInformCard>
         </View>
+        {loading && (
+          <View style={styles.loadingOverlay}>
+            <ActivityIndicator size="large" color="#FFFFFF" />
+          </View>
+        )}
         {showToast && (
           <View
             style={{
@@ -106,3 +114,12 @@ const raw = data.startsWith('https://') ? data.slice('https://'.length) : data;
     </Layout>
   );
 }
+
+const styles = StyleSheet.create({
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## #️⃣연관된 이슈
> #90 

## 📝작업 내용
>  QR 스캔 후 스탬프 인증 과정에서 로딩 상태 처리 추가 및 관련 UI 수정

`src/api/stamp.ts`
`src/components/stamptour/QRCamera.tsx`
`src/pages/QrScan.tsx`

## 🔎코드 설명 및 참고 사항
> - QR 스캔 후 API 호출 중 로딩 오버레이(`ActivityIndicator`) 표시
> - `StampSpot` 인터페이스 및 GraphQL 쿼리에서 `latitude`, `longitude` 필드 제거
> - `QRCamera` 스타일 `StyleSheet.absoluteFill` → `{ flex: 1 }` 변경
> - 인증 실패 메시지 `authFailedNearby` → `authFailedRetry` 통일

### 적용 화면


## 💬리뷰 요구사항

>

## ⚠️로컬 실행 시 유의사항

>
