### PR TITLE
#120 [MOD] 타임테이블 짧은 블록 폰트 크기 조정

### DIFF
--- a/src/components/artist/TimeTable.tsx
+++ b/src/components/artist/TimeTable.tsx
@@ -197,6 +197,7 @@ const TimeTable = () => {
                   HOUR_HEIGHT;
                 const name = artist.performer.name?.ko ?? "-";
                 const isFav = !!artist.performer.isFavorited;
+                const isShort = height < 20; // 12분 미만
 
                 const blockStyle = {
                   position: "absolute" as const,
@@ -221,7 +222,7 @@ const TimeTable = () => {
                       style={blockStyle}
                     >
                       <Text
-                        className={typo.T3_Eb}
+                        className={isShort ? typo.B5_Eb : typo.T3_Eb}
                         numberOfLines={1}
                         style={{ color: "#fff", flex: 1 }}
                       >
@@ -245,7 +246,7 @@ const TimeTable = () => {
                     }}
                   >
                     <Text
-                      className={typo.B3_Eb}
+                      className={isShort ? typo.B5_Eb : typo.B3_Eb}
                       numberOfLines={1}
                       style={{ color: isFav ? "#fff" : "#BFBFBF", flex: 1 }}
                     >


### PR DESCRIPTION
## #️⃣연관된 이슈
> #120 

## 📝작업 내용
>타임테이블에서 블록 높이가 20px 미만(약 12분 미만)인 짧은 공연 블록에 더 작은 폰트 크기 적용       

`src/components/artist/TimeTable.tsx`

## 🔎코드 설명 및 참고 사항
>- 일반 블록: `T3_Eb` / `B3_Eb`
>- 짧은 블록(height < 20): `B5_Eb` 으로 축소하여 텍스트 잘림 방지

### 적용 화면
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/3ea035d5-bbd2-434d-abdf-f016a60800e6" />


## 💬리뷰 요구사항

>

## ⚠️로컬 실행 시 유의사항

>
