### PR TITLE
#135 [ADD] 권한 영구 거절 시 앱 설정 이동 처리 및 실제 GPS 좌표 복원

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-intent-launcher": "~13.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-localization": "~17.0.8",
         "expo-location": "~19.0.8",
@@ -6665,6 +6666,15 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-intent-launcher": {
+      "version": "13.0.8",
+      "resolved": "https://registry.npmjs.org/expo-intent-launcher/-/expo-intent-launcher-13.0.8.tgz",
+      "integrity": "sha512-sgGFotttKKN6dIatjOEJT8M6Arfakus7vIxgshg5VkxarVhZBGJzOJam7rbUlB1O/gQ8em9G8vhEU9AfjEIe7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-intent-launcher": "~13.0.8",
     "expo-linear-gradient": "~15.0.8",
     "expo-localization": "~17.0.8",
     "expo-location": "~19.0.8",

--- a/src/components/map/UserLocationMarker.tsx
+++ b/src/components/map/UserLocationMarker.tsx
@@ -1,6 +1,7 @@
 import * as Location from "expo-location";
 import { useEffect } from "react";
-import { Image } from "react-native";
+import { Alert, Image } from "react-native";
+import { openAppSettings } from "@/utils/openAppSettings";
 import type { SharedValue } from "react-native-reanimated";
 import Animated, {
   useAnimatedStyle,
@@ -48,9 +49,20 @@ const UserLocationMarker = ({
     let sub: Location.LocationSubscription | null = null;
 
     (async () => {
-      const { status } = await Location.requestForegroundPermissionsAsync();
-      // console.log("[GPS] 권한 상태:", status);
-      if (status !== "granted") return;
+      const { status, canAskAgain } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        if (canAskAgain === false) {
+          Alert.alert(
+            "위치 권한 필요",
+            "지도에서 현재 위치를 표시하려면 위치 권한이 필요합니다.",
+            [
+              { text: "취소", style: "cancel" },
+              { text: "설정에서 허용하기", onPress: openAppSettings },
+            ]
+          );
+        }
+        return;
+      }
 
       sub = await Location.watchPositionAsync(
         { accuracy: Location.Accuracy.High, distanceInterval: 2 },

--- a/src/components/stamptour/QRCamera.tsx
+++ b/src/components/stamptour/QRCamera.tsx
@@ -1,6 +1,7 @@
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { openAppSettings } from "@/utils/openAppSettings";
 
 interface QRCameraProps {
   onScanned?: (data: string) => void;
@@ -50,11 +51,17 @@ const QRCamera = forwardRef<QRCameraHandle, QRCameraProps>(function QRCamera({ o
   }
 
   if (!permission.granted) {
+    const handlePermissionPress = permission.canAskAgain
+      ? requestPermission
+      : openAppSettings;
+
     return (
       <View style={styles.center}>
         <Text style={styles.message}>QR코드 스캔을 위해 카메라 권한이 필요합니다.</Text>
-        <TouchableOpacity style={styles.button} onPress={requestPermission}>
-          <Text style={styles.buttonText}>권한 허용</Text>
+        <TouchableOpacity style={styles.button} onPress={handlePermissionPress}>
+          <Text style={styles.buttonText}>
+            {permission.canAskAgain ? "권한 허용" : "설정에서 허용하기"}
+          </Text>
         </TouchableOpacity>
       </View>
     );

--- a/src/pages/QrScan.tsx
+++ b/src/pages/QrScan.tsx
@@ -1,3 +1,4 @@
+
 import { visitStamp } from "@/api/stamp";
 import Layout from "@/components/Layout";
 import QRCamera from "@/components/stamptour/QRCamera";
@@ -6,8 +7,9 @@ import QRScanToast from "@/components/stamptour/QRScanToast";
 import { useNavigation } from "@react-navigation/native";
 import * as Location from "expo-location";
 import { useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
+import { ActivityIndicator, Alert, StyleSheet, View } from "react-native";
+import { openAppSettings } from "@/utils/openAppSettings";
 
 export default function QrScan() {
   const { t } = useTranslation();
@@ -28,18 +30,23 @@ const raw = data.startsWith('https://') ? data.slice('https://'.length) : data;
 
     setLoading(true);
     try {
-      const { status } = await Location.requestForegroundPermissionsAsync();
+      const { status, canAskAgain } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
         setLoading(false);
-        Alert.alert(t('stampTour.locationRequired'), t('stampTour.locationRequiredMsg'), [
-          { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
-        ]);
+        if (canAskAgain === false) {
+          Alert.alert(t('stampTour.locationRequired'), t('stampTour.locationRequiredMsg'), [
+            { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
+            { text: '설정에서 허용하기', onPress: openAppSettings },
+          ]);
+        } else {
+          Alert.alert(t('stampTour.locationRequired'), t('stampTour.locationRequiredMsg'), [
+            { text: t('stampTour.confirm'), onPress: () => navigation.navigate('StampTour') },
+          ]);
+        }
         return;
       }
-      const latitude = 131.1;
-      const longitude = 127.9;
-      //const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      //const { latitude, longitude } = location.coords;
+      const location = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      const { latitude, longitude } = location.coords;
 
       const result = await visitStamp(spotId, latitude, longitude);
       setLoading(false);

--- a/src/utils/openAppSettings.ts
+++ b/src/utils/openAppSettings.ts
@@ -1,0 +1,13 @@
+import * as IntentLauncher from "expo-intent-launcher";
+import { Linking, Platform } from "react-native";
+
+export const openAppSettings = () => {
+  if (Platform.OS === "android") {
+    IntentLauncher.startActivityAsync(
+      IntentLauncher.ActivityAction.APPLICATION_DETAILS_SETTINGS,
+      { data: "package:com.playtap.app" }
+    );
+  } else {
+    Linking.openSettings();
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed : #135 

## 📝작업 내용
> 카메라/위치 권한이 영구 거절된 경우(`canAskAgain ===false`) 앱 설정으로 이동할 수 있도록 처리하고, QrScan의 하드코딩 좌표를 실제 GPS 좌표로 복원

`src/utils/openAppSettings.ts`
`src/components/map/UserLocationMarker.tsx`
`src/components/stamptour/QRCamera.tsx`
`src/pages/QrScan.tsx`
`package.json` / `package-lock.json`

## 🔎코드 설명 및 참고 사항
> - `expo-intent-launcher` 패키지 추가
> - `openAppSettings` 유틸 생성: Android는 `IntentLauncher`로 앱 상세 설정 이동, iOS는 `Linking.openSettings()` 사용
> - `UserLocationMarker`: `canAskAgain === false`일 때  Alert에 "설정에서 허용하기" 버튼 추가
> - `QRCamera`: `canAskAgain === false`일 때 버튼 텍스트를 "설정에서 허용하기"로 변경하고 `openAppSettings` 호출
> - `QrScan`: 위치 권한 영구 거절 시 설정 이동 버튼 추가, 하드코딩된 테스트 좌표 제거 후 실제 `getCurrentPositionAsync` 복원

### 적용 화면


## 💬리뷰 요구사항
>권한 영구 거절 시 → Alert 또는 버튼으로 설정 앱 이동 유도

## ⚠️로컬 실행 시 유의사항
 > `expo-intent-launcher` 패키지가 추가되었으므로 `npm install` 후 실행 필요
